### PR TITLE
Do not override custom logger in railtie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Do not override custom logger in railtie
+
 ## 0.3.0 (2023-11-09)
 
   - Add ability to trace columns usage in custom code

--- a/lib/columns_trace/railtie.rb
+++ b/lib/columns_trace/railtie.rb
@@ -7,7 +7,7 @@ module ColumnsTrace
       ColumnsTrace.backtrace_cleaner = Rails.backtrace_cleaner
 
       logger = ActiveSupport::Logger.new(Rails.root.join("log", "columns_trace.log"))
-      ColumnsTrace.reporter = LogReporter.new(logger)
+      ColumnsTrace.reporter ||= LogReporter.new(logger)
     end
   end
 end


### PR DESCRIPTION
If the reporter is set explicitly it will be overloaded by default. 
Please see https://github.com/fatkodima/columns_trace?tab=readme-ov-file#custom-reporters. 